### PR TITLE
Added a CHANGELOG and autoupdate changelog on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Initial release
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
CHANGELOG follows https://keepachangelog.com/en/1.0.0/
Note that the autoupdate is slightly broken and will require manual adjustment for the first release, but subsequent releases should be fine