### PR TITLE
Features/tag release flow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,26 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'release-*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Gradle Build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: build
+      - name: Release
+        uses: docker://antonyurchenko/git-release:latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRAFT_RELEASE: "true"
+        with:
+          args: build/libs/simplehealthbars2-*-all.jar

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           arguments: build
       - name: Release
-        uses: docker://antonyurchenko/git-release:latest
+        uses: SimpleMC/git-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRAFT_RELEASE: "true"

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -17,10 +17,19 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         with:
           arguments: build
+      - name: Extract version
+        uses: frabert/replace-string-action@master
+        id: format-version
+        with:
+          pattern: 'refs/tags/release-([0-9]+.[0-9]+.[0-9]+)'
+          string: ${{ github.ref }}
+          replace-with: '$1'
       - name: Release
         uses: SimpleMC/git-release@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRAFT_RELEASE: "true"
         with:
-          args: build/libs/simplehealthbars2-*-all.jar
+          args: |
+            build/libs/simplehealthbars2-${{ steps.format-version.outputs.replaced }}.jar
+            build/libs/simplehealthbars2-${{ steps.format-version.outputs.replaced }}-all.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Release workflow to add a draft GH release on tag
 
 ## [0.1.0] - 2019-12-18
 ### Added


### PR DESCRIPTION
Couple things to note here:
- We have to use our own fork of the [anton-yurchenko/git-release](https://github.com/SimpleMC/git-release) action to support our `release-` tag prefix. See [SimpleMC/git-release](https://github.com/SimpleMC/git-release). See PR at anton-yurchenko/git-release#3
- This created the following release on tag 
![image](https://user-images.githubusercontent.com/4847023/71057243-169dba00-212a-11ea-9e08-af8f99b719a5.png)
(which I subsequently deleted)
