### PR TITLE
Use accounted (final) damage instead of raw damage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- Fixed Damage listener using incorrect value to calculate health (#11)
 - Switched from SimpleMC/git-release back to antonyurchenko/git-release for release action
 
 ## [0.1.1] - 2019-12-18

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/DamageListener.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/DamageListener.kt
@@ -28,7 +28,7 @@ class DamageListener(
         val source = event.damager as? LivingEntity
 
         // put source and target healthbars
-        healthbar(source, target, event.damage)
+        healthbar(source, target, event.finalDamage)
         source?.let { healthbar(target, it, 0.0) }
     }
 


### PR DESCRIPTION
event.damage is the raw damage done, and doesn't account for armor or potion effects. This means that the health bar will display inaccurate information for players who are wearing armor, and significantly inaccurate information for heavily enchanted armor.