### PR TITLE
Add explicit exception and documentation for when types are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Updated README for clarity around types and styles valid for a specific configuration
+
+### Fixed
+- Add explicit exception when healthbar `type` is invalid for a specific bar configuration
 
 ## [0.1.3] - 2020-02-11
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Simple, easy-to-use healthbar plugin with optional player and mob healthbars
 
 ```yaml
 player-bar:
-  type: SCOREBOARD
-  style: ABSOLUTE
+  type: SCOREBOARD # healthbar type (AKA location, can be SCOREBOARD or ACTION)
+  style: ABSOLUTE # style of healthbar (ABSOLUTE, PERCENT, or BAR)
 
 mob-bar:
   type: NAME # healthbar type (AKA location, can be SCOREBOARD, NAME, or ACTION)
@@ -23,12 +23,12 @@ mob-bar:
 
 ### Available `type`s
 
-- `SCOREBOARD` - Below-name healthbar using the scoreboard API
-- `NAME` - Updates entity's custom name to include health
-- `ACTION` - Uses a player's action bar to display recently-damaged entity's health
+- `SCOREBOARD` - Below-name healthbar using the scoreboard API (valid for: `player-bar`)
+- `NAME` - Updates entity's custom name to include health (valid for: `mob-bar`)
+- `ACTION` - Uses a player's action bar to display recently-damaged entity's health (valid for: `player-bar`, `mob-bar`)
 
 ### Available `style`s
 
 - `ABSOLUTE` - Health is displayed as actual health value (hearts)
 - `PERCENT` - Health is displayed as a percentage of max health
-- `BAR` - Health is displayed as a portion of a bar, configured by `length` and `char` properties
+- `BAR` - Health is displayed as a portion of a bar, configured by `length` and `char` properties (not valid for `SCOREBOARD` type bar)

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
@@ -22,8 +22,16 @@ class SimpleHealthbars2 : JavaPlugin() {
 
         listener = DamageListener(
             this,
-            config.getConfigurationSection("player-bar")?.let { loadBar(it) } as PlayerHealthbar?,
-            config.getConfigurationSection("mob-bar")?.let { loadBar(it) } as MobHealthbar?
+            config.getConfigurationSection("player-bar")?.let {
+                loadBar(it)?.let { bar ->
+                    checkNotNull(bar as? PlayerHealthbar) { "Invalid player healthbar type! Must be one of: SCOREBOARD, ACTION" }
+                }
+            },
+            config.getConfigurationSection("mob-bar")?.let {
+                loadBar(it)?.let { bar ->
+                    checkNotNull(bar as? MobHealthbar) { "Invalid mob healthbar type! Must be one of: NAME, ACTION" }
+                }
+            }
         )
 
         server.pluginManager.registerEvents(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,10 @@
-
 player-bar:
-  type: SCOREBOARD
-  style: ABSOLUTE
+  type: SCOREBOARD # healthbar type (AKA location, can be SCOREBOARD or ACTION)
+  style: ABSOLUTE # style of healthbar (ABSOLUTE, PERCENT, or BAR)
 
 mob-bar:
-  type: NAME
-  style: BAR
-  length: 20
-  char: 0x25ae
-  showMobNames: true
+  type: NAME # healthbar type (AKA location, can be NAME or ACTION)
+  style: BAR # style of healthbar (ABSOLUTE, PERCENT, or BAR)
+  length: 20 # length of the bar (number of characters)
+  char: 0x25ae # character to use for the bar
+  showMobNames: true # if the mob's name should show alongside the healthbar (for NAME or ACTION type)


### PR DESCRIPTION
References #15

As per #15, choosing an invalid type for given configuration used to result in an unclear `ClassCastException`:
```
java.lang.ClassCastException: org.simplemc.simplehealthbars2.healthbar.NameHealthbar cannot be cast to org.simplemc.simplehealthbars2.healthbar.PlayerHealthbar
```

Now, you'll end up with:
```
java.lang.IllegalStateException: Invalid player healthbar type! Must be one of: SCOREBOARD, ACTION
```
or
```
java.lang.IllegalStateException: Invalid mob healthbar type! Must be one of: NAME, ACTION
```

Ideally, these would come from code rather than being specified in the string literal, but that'll require some reorganization.