### PR TITLE
Added option to use the main scoreboard for the scoreboard healthbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `useMainScoreboard` config option on `SCOREBOARD` healthbars to configure if it should use the main scoreboard (`true`) or a new one (`false`) (default: `false`)
+
 ### Changed
 - Updated README for clarity around types and styles valid for a specific configuration
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Simple, easy-to-use healthbar plugin with optional player and mob healthbars
 player-bar:
   type: SCOREBOARD # healthbar type (AKA location, can be SCOREBOARD or ACTION)
   style: ABSOLUTE # style of healthbar (ABSOLUTE, PERCENT, or BAR)
+  useMainScoreboard: false # use the main scoreboard (true) or a new scoreboard (false)
 
 mob-bar:
   type: NAME # healthbar type (AKA location, can be SCOREBOARD, NAME, or ACTION)

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
@@ -1,5 +1,6 @@
 package org.simplemc.simplehealthbars2
 
+import org.bukkit.Bukkit
 import org.bukkit.configuration.ConfigurationSection
 import org.bukkit.plugin.java.JavaPlugin
 import org.simplemc.simplehealthbars2.healthbar.ActionHealthbar
@@ -8,6 +9,7 @@ import org.simplemc.simplehealthbars2.healthbar.MobHealthbar
 import org.simplemc.simplehealthbars2.healthbar.NameHealthbar
 import org.simplemc.simplehealthbars2.healthbar.PlayerHealthbar
 import org.simplemc.simplehealthbars2.healthbar.ScoreboardHealthbar
+import org.simplemc.simplehealthbars2.healthbar.ScoreboardHealthbar.Companion.OBJECTIVE_NAME
 import org.simplemc.simplehealthbars2.healthbar.StringHealthbar
 
 /**
@@ -48,6 +50,7 @@ class SimpleHealthbars2 : JavaPlugin() {
             Healthbar.Type.ACTION -> ActionHealthbar(loadStringBar(config))
             Healthbar.Type.SCOREBOARD -> ScoreboardHealthbar(
                 ScoreboardHealthbar.Config(
+                    useMainScoreboard = config.getBoolean("useMainScoreboard", false),
                     style = Healthbar.Style.valueOf(checkNotNull(config.getString("style", "ABSOLUTE")))
                 )
             )
@@ -63,6 +66,7 @@ class SimpleHealthbars2 : JavaPlugin() {
 
     override fun onDisable() {
         listener.close()
+        Bukkit.getScoreboardManager()?.mainScoreboard?.getObjective(OBJECTIVE_NAME)?.unregister()
         logger.info("${description.name} disabled.")
     }
 }

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/ScoreboardHealthbar.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/ScoreboardHealthbar.kt
@@ -11,21 +11,39 @@ import org.simplemc.simplehealthbars2.getDamagedHealthRatio
 import kotlin.math.ceil
 
 class ScoreboardHealthbar(private val config: Config) : PlayerHealthbar {
-    data class Config(val style: Healthbar.Style = Healthbar.Style.ABSOLUTE)
+
+    companion object {
+        const val OBJECTIVE_NAME = "simplehealthbar"
+    }
+
+    data class Config(
+        val useMainScoreboard: Boolean = false,
+        val style: Healthbar.Style = Healthbar.Style.ABSOLUTE
+    )
 
     private val objective: Objective
 
     init {
         val scoreboardManager = checkNotNull(Bukkit.getScoreboardManager())
+
+        // clean up previously added objective if it exists
+        scoreboardManager.mainScoreboard.getObjective(OBJECTIVE_NAME)?.unregister()
+
+        val scoreboard = if (config.useMainScoreboard) {
+            scoreboardManager.mainScoreboard
+        } else {
+            scoreboardManager.newScoreboard
+        }
+
         objective = when (config.style) {
-            Healthbar.Style.ABSOLUTE -> scoreboardManager.newScoreboard.registerNewObjective(
-                "healthbar",
+            Healthbar.Style.ABSOLUTE -> scoreboard.registerNewObjective(
+                OBJECTIVE_NAME,
                 "health",
                 "${ChatColor.RED}${0x2764.toChar()}",
                 RenderType.HEARTS
             )
-            Healthbar.Style.PERCENT -> scoreboardManager.newScoreboard.registerNewObjective(
-                "healthbar",
+            Healthbar.Style.PERCENT -> scoreboard.registerNewObjective(
+                OBJECTIVE_NAME,
                 "dummy",
                 "${ChatColor.RED}${0x2764.toChar()}",
                 RenderType.INTEGER

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,7 @@
 player-bar:
   type: SCOREBOARD # healthbar type (AKA location, can be SCOREBOARD or ACTION)
   style: ABSOLUTE # style of healthbar (ABSOLUTE, PERCENT, or BAR)
+  useMainScoreboard: false # use the main scoreboard (true) or a new scoreboard (false)
 
 mob-bar:
   type: NAME # healthbar type (AKA location, can be NAME or ACTION)


### PR DESCRIPTION
Relates to discussion in #19 

The main caveat with using the main scoreboard (and the reason I chose to not make it default) is that the main scoreboard is assigned to players by default so the health will always show, rather than for 5s after taking damage (assuming there isn't already an objective in that slot).