### PR TITLE
Feature/gh 22/persistent bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- GH-22: Always on healthbars for NAME or SCOREBOARD via special-case `always` duration (@tajobe)
+
 ## [0.4.0] - 2025-02-17
 ### Changed
 - MC 1.21, Kotlin 2.1, Gradle 8.12 (@tajobe)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/DamageListener.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/DamageListener.kt
@@ -27,7 +27,7 @@ class DamageListener(
     private val scheduler = Bukkit.getScheduler()
     private val removeHealthbarTasks: MutableMap<UUID, RemoveHealthbarTask?> = mutableMapOf()
 
-    // <editor-fold desc="Set always on healthbards on spawn/join">
+    // <editor-fold desc="Set always on healthbars on spawn/join">
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     fun onEntitySpawn(event: EntitySpawnEvent) {
         val entity = event.entity as? LivingEntity
@@ -49,7 +49,7 @@ class DamageListener(
     // </editor-fold>
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    fun onEntityDamageEvent(event: EntityDamageByEntityEvent) {
+    fun onEntityDamageByEntityEvent(event: EntityDamageByEntityEvent) {
         val target = event.entity as? LivingEntity ?: return
         val source = event.damager as? LivingEntity
 

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/SimpleHealthbars2.kt
@@ -62,10 +62,10 @@ class SimpleHealthbars2 : JavaPlugin() {
                 Loaded Healthbar configs:
                 Player bars:
                 ${barsConfigToString(playerHealthbars)}
-                
+
                 Mob bars:
                 ${barsConfigToString(mobHealthbars)}
-                
+
             """.trimIndent()
         }
 
@@ -87,7 +87,7 @@ class SimpleHealthbars2 : JavaPlugin() {
                     ScoreboardHealthbar.Config(
                         useMainScoreboard = config.getBoolean("useMainScoreboard", false),
                         style = Healthbar.Style.valueOf(checkNotNull(config.getString("style", "ABSOLUTE"))),
-                        duration = Duration.ofSeconds(config.getLong("duration", 5)),
+                        duration = loadBarDuration(config),
                     ),
                 )
                 Healthbar.Type.NONE -> null
@@ -96,11 +96,19 @@ class SimpleHealthbars2 : JavaPlugin() {
 
     private fun loadStringBar(config: ConfigurationSection) = StringHealthbar.Config(
         style = Healthbar.Style.valueOf(checkNotNull(config.getString("style", "BAR"))),
-        duration = Duration.ofSeconds(config.getLong("duration", 5)),
+        duration = loadBarDuration(config),
         length = config.getInt("length", 20),
         char = config.getInt("char", 0x25ae).toChar(),
         showMobNames = config.getBoolean("showMobNames", true),
     )
+
+    private fun loadBarDuration(config: ConfigurationSection): Duration? = config.getString("duration").let {
+        if (it == "always") {
+            null
+        } else {
+            Duration.ofSeconds(it?.toLongOrNull() ?: 5L)
+        }
+    }
 
     override fun onDisable() {
         listener.close()

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/Healthbar.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/Healthbar.kt
@@ -9,12 +9,12 @@ interface Healthbar {
 
     interface Config {
         val style: Style
-        val duration: Duration
+        val duration: Duration?
     }
 
     val config: Config
-    val durationTicks: Long
-        get() = config.duration.seconds * 20
+    val durationTicks: Long?
+        get() = config.duration?.seconds?.times(20)
 
     /**
      * Update target's healthbar with latest health

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/ScoreboardHealthbar.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/ScoreboardHealthbar.kt
@@ -21,7 +21,7 @@ class ScoreboardHealthbar(override val config: Config) : PlayerHealthbar {
     data class Config(
         val useMainScoreboard: Boolean = false,
         override val style: Healthbar.Style = Healthbar.Style.ABSOLUTE,
-        override val duration: Duration = Duration.ofSeconds(5),
+        override val duration: Duration? = Duration.ofSeconds(5),
     ) : Healthbar.Config
 
     private val objective: Objective

--- a/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/StringHealthbar.kt
+++ b/src/main/kotlin/org/simplemc/simplehealthbars2/healthbar/StringHealthbar.kt
@@ -10,7 +10,7 @@ import kotlin.math.ceil
 abstract class StringHealthbar(final override val config: Config) : Healthbar {
     data class Config(
         override val style: Healthbar.Style = Healthbar.Style.BAR,
-        override val duration: Duration = Duration.ofSeconds(5),
+        override val duration: Duration? = Duration.ofSeconds(5),
         val length: Int = 20,
         val char: Char = 0x25ae.toChar(),
         val showMobNames: Boolean = true,


### PR DESCRIPTION
Adds an always-on healthbar option for NAME (mob) and SCOREBOARD (player) healthbar configs via special-case `duration` config.

This has a couple implications requiring follow-up:
- We aren't processing all entity damage events, only damage by entities. This is fine normally because a healthbar only shows for a few seconds _when damaged from an entity_, but for permanent bars damage like falling or fire really should keep the bar up to date. One complication is it shouldn't create a bar, just update one if showing. See #29.
- Given healthbars will let you see mobs through the world, I imagine one might want to limit which mobs it applies to. See #30.

That said, they could be used as-is if desired.

---

Completes #22 